### PR TITLE
Allow `/* ... */` multiline comments

### DIFF
--- a/syntaxes/ron.tmGrammar.json
+++ b/syntaxes/ron.tmGrammar.json
@@ -35,7 +35,7 @@
     },
     "block_comment": {
       "name": "punctuation.definition.comment.ron",
-      "begin": "/\\*\\*(?!/)",
+      "begin": "/\\*",
       "end": "\\*/"
     },
     "constant": {


### PR DESCRIPTION
Fixes #1 multi-line comments highlighting