### PR TITLE
Bugfix: Array of objects not properly highlighted

### DIFF
--- a/syntaxes/ron.tmGrammar.json
+++ b/syntaxes/ron.tmGrammar.json
@@ -27,10 +27,10 @@
       "endCaptures": {
         "0": { "name": "punctuation.section.array.end.ron" }
       },
-
       "patterns": [
-        { "meta_scope": "meta.structure.array.ron" },
-        { "include": "#value" }
+        { "include": "#value" },
+        { "include": "#object-name" },
+        { "meta_scope": "meta.structure.array.ron" }
       ]
     },
     "block_comment": {

--- a/syntaxes/ron.tmGrammar.json
+++ b/syntaxes/ron.tmGrammar.json
@@ -91,7 +91,7 @@
       ]
     },
     "number": {
-      "match": "(?x:         # turn on extended mode\n  -?         # an optional minus\n  (?:\n    0        # a zero\n    |        # ...or...\n    [1-9]    # a 1-9 character\n    \\d*      # followed by zero or more digits\n  )\n  (?:\n    (?:\n      \\.     # a period\n      \\d+    # followed by one or more digits\n    )?\n    (?:\n      [eE]   # an e character\n      [+-]?  # followed by an option +/-\n      \\d+    # followed by one or more digits\n    )?       # make exponent optional\n  )?         # make decimal portion optional\n)",
+      "match": "(?x:-?(?:0|[1-9]\\d*)(?:(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)?)",
       "name": "constant.numeric.ron"
     },
     "string": {


### PR DESCRIPTION
- [x] Fixed issue where arrays of structs/enums where not properly highlighted. 
- [x] Remove superfluous comments from number pattern.

### Previously
<img width="162" alt="Screen Shot 2019-10-15 at 10 46 17 PM" src="https://user-images.githubusercontent.com/146222/66891310-a47bee00-ef9d-11e9-9c22-5a7612d8e611.png">

### Updated  🎉 
<img width="168" alt="Screen Shot 2019-10-15 at 10 48 06 PM" src="https://user-images.githubusercontent.com/146222/66891402-e9a02000-ef9d-11e9-9634-074840e13d91.png">

