### PR TITLE
Add single-quoted characters, fixes broken syntax with embedded brace…

### DIFF
--- a/syntaxes/ron.tmGrammar.json
+++ b/syntaxes/ron.tmGrammar.json
@@ -15,6 +15,7 @@
         { "include": "#object-name" },
         { "include": "#object" },
         { "include": "#string" },
+        { "include": "#character" },
         { "include": "#tag-name" }
       ]
     },
@@ -99,6 +100,12 @@
       "end": "\"",
       "name": "string.quoted.double"
     },
+    "character": {
+      "begin": "'",
+      "end": "'",
+      "contentName": "constant.character.ron",
+      "name": "string.quoted.single"
+    },
     "value": {
       "patterns": [
         { "include": "#array" },
@@ -108,7 +115,8 @@
         { "include": "#line_comment" },
         { "include": "#number" },
         { "include": "#object" },
-        { "include": "#string" }
+        { "include": "#string" },
+        { "include": "#character" }
       ]
     }
   }


### PR DESCRIPTION
Adds simple support for single-quoted characters.

Before, the highlighting would be messed up if an open bracket `{` was included inside a character value.

Example `.ron` file showing the problem.

```ron
BracketParseFailure(
    char1: 'c',
    char2: '{',  // Notice how this changes char3's parsing color
    char3: '}',  // But then we close it in a second char
    char4: 'x',
    char5: '}',  // Here there are no matching pairs, color is red as it tried to match
    char6: '{',  // And every property below is messed up due to un-closed "open"
    messedUp1: "example",
    messedUp2: false,
)
```