### PR TITLE
feat: Add RON document formatting support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
+out/
 *.txt

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,8 +1,8 @@
 .vscode/**
 .vscode-test/**
+src/**
+node_modules/**
+tsconfig.json
+**/*.ts
+**/*.map
 .gitignore
-vsc-extension-quickstart.md
-*.txt
-syntaxes/*
-!syntaxes/ron.tmGrammar.json
-node_modules

--- a/README.md
+++ b/README.md
@@ -18,6 +18,42 @@ designed to support all of Serde's data model. Check out the RON repository
 for more information!
 
 
+## RON Formatting
+
+This extension supports document formatting for RON files via an external formatter binary.
+
+### Setup
+
+1. **Install a RON formatter.** The default is [`fmtron`](https://crates.io/crates/fmtron):
+   ```bash
+   cargo install fmtron
+   ```
+
+2. **Format your file** using `Shift+Alt+F` (or `Shift+Option+F` on macOS), or right-click → "Format Document".
+
+3. **Format on save** (optional): Add to your `settings.json`:
+   ```json
+   {
+     "[ron]": {
+       "editor.formatOnSave": true,
+       "editor.defaultFormatter": "a5huynh.vscode-ron"
+     }
+   }
+   ```
+
+### Configuration
+
+| Setting | Default | Description |
+|---|---|---|
+| `ron.formatter.path` | `"fmtron"` | Path to the formatter binary |
+| `ron.formatter.maxWidth` | `80` | Max line width (soft limit) |
+| `ron.formatter.useStdin` | `false` | Pipe via stdin/stdout instead of temp file |
+| `ron.formatter.extraArgs` | `[]` | Additional CLI arguments |
+
+> **Note:** `fmtron` does not preserve comments. See the [fmtron README](https://github.com/barafael/fmtron) for details and limitations.
+
+You can use any RON formatter that accepts a file path argument. If your formatter reads from stdin and writes to stdout, enable `ron.formatter.useStdin`.
+
 ## Highlighting Example
 
 Here's a lovely example of what a basic `.ron` file will now look like:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,43 @@
 {
     "name": "vscode-ron",
-    "version": "0.11.0",
+    "version": "0.12.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-ron",
-            "version": "0.11.0",
+            "version": "0.12.0",
             "license": "MIT",
             "dependencies": {
                 "vsce": "^2.14.0",
                 "vscode-oniguruma": "^2.0.1",
                 "vscode-textmate": "^9.3.2"
             },
+            "devDependencies": {
+                "@types/node": "^18.19.130",
+                "@types/vscode": "^1.75.0",
+                "typescript": "^5.9.3"
+            },
             "engines": {
-                "vscode": "^1.30.0"
+                "vscode": "^1.75.0"
             }
+        },
+        "node_modules/@types/node": {
+            "version": "18.19.130",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+            "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
+        },
+        "node_modules/@types/vscode": {
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.75.0.tgz",
+            "integrity": "sha512-SAr0PoOhJS6FUq5LjNr8C/StBKALZwDVm3+U4pjF/3iYkt3GioJOPV/oB1Sf1l7lROe4TgrMyL5N1yaEgTWycw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/ansi-styles": {
             "version": "3.2.1",
@@ -1147,6 +1169,20 @@
                 "underscore": "^1.12.1"
             }
         },
+        "node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
         "node_modules/uc.micro": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -1156,6 +1192,13 @@
             "version": "1.13.6",
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
             "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
+        },
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/url-join": {
             "version": "4.0.1",
@@ -1263,6 +1306,21 @@
         }
     },
     "dependencies": {
+        "@types/node": {
+            "version": "18.19.130",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+            "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+            "dev": true,
+            "requires": {
+                "undici-types": "~5.26.4"
+            }
+        },
+        "@types/vscode": {
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.75.0.tgz",
+            "integrity": "sha512-SAr0PoOhJS6FUq5LjNr8C/StBKALZwDVm3+U4pjF/3iYkt3GioJOPV/oB1Sf1l7lROe4TgrMyL5N1yaEgTWycw==",
+            "dev": true
+        },
         "ansi-styles": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -2055,6 +2113,12 @@
                 "underscore": "^1.12.1"
             }
         },
+        "typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true
+        },
         "uc.micro": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -2064,6 +2128,12 @@
             "version": "1.13.6",
             "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
             "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
+        },
+        "undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "dev": true
         },
         "url-join": {
             "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "vscode-ron",
     "displayName": "vscode-ron",
-    "description": "Rusty Object Notation (RON) syntax package",
+    "description": "Rusty Object Notation (RON) syntax package with formatting support",
     "publisher": "a5huynh",
     "license": "MIT",
     "homepage": "https://github.com/a5huynh/vscode-ron",
@@ -12,13 +12,23 @@
         "type": "git",
         "url": "https://github.com/a5huynh/vscode-ron"
     },
-    "version": "0.11.0",
+    "version": "0.12.0",
     "engines": {
-        "vscode": "^1.30.0"
+        "vscode": "^1.75.0"
     },
     "categories": [
-        "Programming Languages"
+        "Programming Languages",
+        "Formatters"
     ],
+    "activationEvents": [
+        "onLanguage:ron"
+    ],
+    "main": "./out/extension.js",
+    "scripts": {
+        "vscode:prepublish": "npm run compile",
+        "compile": "node node_modules/typescript/bin/tsc -p ./",
+        "watch": "node node_modules/typescript/bin/tsc -watch -p ./"
+    },
     "contributes": {
         "languages": [
             {
@@ -39,7 +49,50 @@
                 "scopeName": "source.ron",
                 "path": "./syntaxes/ron.tmGrammar.json"
             }
-        ]
+        ],
+        "commands": [
+            {
+                "command": "ron.formatDocument",
+                "title": "Format RON Document",
+                "category": "RON"
+            }
+        ],
+        "configuration": {
+            "title": "RON",
+            "properties": {
+                "ron.formatter.path": {
+                    "type": "string",
+                    "default": "fmtron",
+                    "description": "Path to the RON formatter binary (e.g., fmtron). Must be installed and available on PATH, or provide an absolute path."
+                },
+                "ron.formatter.maxWidth": {
+                    "type": "number",
+                    "default": 80,
+                    "description": "Maximum line width for the formatter (soft limit)."
+                },
+                "ron.formatter.useStdin": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "If true, pipe document content via stdin/stdout instead of using a temporary file. Enable this if your formatter supports stdin mode."
+                },
+                "ron.formatter.extraArgs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "description": "Additional arguments to pass to the formatter binary."
+                },
+                "[ron]": {
+                    "editor.defaultFormatter": "a5huynh.vscode-ron"
+                }
+            }
+        }
+    },
+    "devDependencies": {
+        "@types/node": "^18.19.130",
+        "@types/vscode": "^1.75.0",
+        "typescript": "^5.9.3"
     },
     "dependencies": {
         "vsce": "^2.14.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,139 @@
+import * as vscode from "vscode";
+import { execFile } from "child_process";
+import { tmpdir } from "os";
+import { join } from "path";
+import { writeFile, readFile, unlink } from "fs/promises";
+import { randomBytes } from "crypto";
+
+class RonFormattingProvider
+  implements vscode.DocumentFormattingEditProvider
+{
+  provideDocumentFormattingEdits(
+    document: vscode.TextDocument,
+    options: vscode.FormattingOptions,
+    token: vscode.CancellationToken
+  ): Promise<vscode.TextEdit[]> {
+    return formatDocument(document, options, token);
+  }
+}
+
+async function formatDocument(
+  document: vscode.TextDocument,
+  options: vscode.FormattingOptions,
+  token: vscode.CancellationToken
+): Promise<vscode.TextEdit[]> {
+  const config = vscode.workspace.getConfiguration("ron");
+  const formatterPath = config.get<string>("formatter.path", "fmtron");
+  const extraArgs = config.get<string[]>("formatter.extraArgs", []);
+  const tabSize = options.tabSize ?? 4;
+  const maxWidth = config.get<number>("formatter.maxWidth", 80);
+  const useStdin = config.get<boolean>("formatter.useStdin", false);
+
+  const text = document.getText();
+
+  if (useStdin) {
+    // Pipe mode: send content via stdin, read formatted output from stdout
+    return new Promise((resolve, reject) => {
+      const args = [...extraArgs];
+      const proc = execFile(
+        formatterPath,
+        args,
+        { timeout: 10000, maxBuffer: 10 * 1024 * 1024 },
+        (error, stdout, stderr) => {
+          if (error) {
+            vscode.window.showErrorMessage(
+              `RON formatter error: ${stderr || error.message}`
+            );
+            resolve([]);
+            return;
+          }
+          const fullRange = new vscode.Range(
+            document.positionAt(0),
+            document.positionAt(text.length)
+          );
+          resolve([vscode.TextEdit.replace(fullRange, stdout)]);
+        }
+      );
+      if (proc.stdin) {
+        proc.stdin.write(text);
+        proc.stdin.end();
+      }
+      token.onCancellationRequested(() => proc.kill());
+    });
+  }
+
+  // File mode (default for fmtron): write to temp file, run formatter, read result
+  const tmpFile = join(
+    tmpdir(),
+    `vscode-ron-${randomBytes(8).toString("hex")}.ron`
+  );
+
+  try {
+    await writeFile(tmpFile, text, "utf-8");
+
+    const formatted = await new Promise<string>((resolve, reject) => {
+      // fmtron: use -d to print to stdout, -t for tab size, -w for max width
+      const args = [
+        tmpFile,
+        "-d",
+        "-t",
+        String(tabSize),
+        "-w",
+        String(maxWidth),
+        ...extraArgs,
+      ];
+
+      const proc = execFile(
+        formatterPath,
+        args,
+        { timeout: 10000, maxBuffer: 10 * 1024 * 1024 },
+        (error, stdout, stderr) => {
+          if (error) {
+            reject(new Error(stderr || error.message));
+            return;
+          }
+          resolve(stdout);
+        }
+      );
+      token.onCancellationRequested(() => proc.kill());
+    });
+
+    if (formatted === text) {
+      return [];
+    }
+
+    const fullRange = new vscode.Range(
+      document.positionAt(0),
+      document.positionAt(text.length)
+    );
+    return [vscode.TextEdit.replace(fullRange, formatted)];
+  } catch (err: any) {
+    vscode.window.showErrorMessage(`RON formatter error: ${err.message}`);
+    return [];
+  } finally {
+    unlink(tmpFile).catch(() => {});
+    unlink(tmpFile + ".bak").catch(() => {}); // fmtron creates .bak files
+  }
+}
+
+export function activate(context: vscode.ExtensionContext): void {
+  const provider = new RonFormattingProvider();
+
+  context.subscriptions.push(
+    vscode.languages.registerDocumentFormattingEditProvider("ron", provider)
+  );
+
+  // Register a manual format command
+  context.subscriptions.push(
+    vscode.commands.registerCommand("ron.formatDocument", async () => {
+      const editor = vscode.window.activeTextEditor;
+      if (editor && editor.document.languageId === "ron") {
+        await vscode.commands.executeCommand(
+          "editor.action.formatDocument"
+        );
+      }
+    })
+  );
+}
+
+export function deactivate(): void {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "outDir": "out",
+    "lib": ["es2020"],
+    "sourceMap": true,
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "exclude": ["node_modules", ".vscode-test"]
+}


### PR DESCRIPTION
## Summary

Adds document formatting support for RON files by integrating with an external formatter binary (defaults to [fmtron](https://crates.io/crates/fmtron)).

Closes #5

## Changes

- **New:** `DocumentFormattingEditProvider` that shells out to a configurable RON formatter
- **New:** TypeScript build infrastructure (tsconfig.json, compile scripts, extension entry point)
- **New:** Configuration options: `ron.formatter.path`, `ron.formatter.maxWidth`, `ron.formatter.useStdin`, `ron.formatter.extraArgs`
- **New:** `ron.formatDocument` command
- **Updated:** README with formatting setup and configuration docs
- **Updated:** Version bump to 0.12.0

## How it works

By default, the extension writes the document to a temp file, runs `fmtron <file> -d` (outputs to stdout), and replaces the document content. For formatters that support stdin/stdout, enable `ron.formatter.useStdin`.

## Setup

```bash
cargo install fmtron
```

Then use Shift+Alt+F to format, or enable format-on-save.